### PR TITLE
Add preflight checks for required system binaries

### DIFF
--- a/bhdup/preflight.py
+++ b/bhdup/preflight.py
@@ -14,17 +14,27 @@ REQUIRED_BINARIES = {
 }
 
 
-def check_binaries() -> None:
+def check_binaries(verbose: bool = False) -> None:
     """Verify all required external tools are installed.
 
     Prints a clear message for each missing binary and exits
-    if any are not found.
+    if any are not found. When verbose is True, also prints
+    the resolved path for each found binary.
     """
     missing: list[str] = []
+    found: list[str] = []
 
     for binary, purpose in REQUIRED_BINARIES.items():
-        if shutil.which(binary) is None:
+        path = shutil.which(binary)
+        if path is None:
             missing.append(f"  - {binary}: {purpose}")
+        else:
+            found.append(f"  - {binary}: {path}")
+
+    if found and verbose:
+        print("Found required binaries:")
+        for line in found:
+            print(line)
 
     if missing:
         print("Error: missing required system binaries:", file=sys.stderr)


### PR DESCRIPTION
Adds `bhdup/preflight.py` with a `check_binaries()` function that verifies all required external tools are available before the main loop runs.

Checks: `ffmpeg`, `mktorrent`, `mediainfo`, `imgbox`

Each missing tool is listed with its purpose and install hint. Prevents partial execution and orphaned temp files from missing dependencies.

Fixes #2